### PR TITLE
feat: simplify locale flag display in LocaleWidget

### DIFF
--- a/src/components/LocaleWidget.tsx
+++ b/src/components/LocaleWidget.tsx
@@ -158,11 +158,7 @@ const LocaleWidget: React.FC<LocaleWidgetProps> = ({
                                         }
                                     }}
                                 >
-                                    <span className="locale-flag"><img
-                                        src={`https://flagicons.lipis.dev/flags/4x3/${locale.flag}.svg`}
-                                        alt={`${locale.name} flag`}
-                                        className="locale-flag-img"
-                                    /></span>
+                                    <span className="locale-flag">{locale.flag}</span>
                                     <span className="locale-name">{locale.name}</span>
                                     {locale.code === currentLocale && <span className="checkmark">✓</span>}
                                 </div>


### PR DESCRIPTION
Fixes the flags not showing up in the LocaleWidget.

<img width="368" height="223" alt="image" src="https://github.com/user-attachments/assets/bf6d97e6-1d19-43d9-94b0-3239e339db31" />

